### PR TITLE
v1.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.0.1
+mod_version=1.6-fabric-1.1.0
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=unchained
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/UnchainedMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/UnchainedMod.kt
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer
 import us.timinc.mc.cobblemon.unchained.modules.HiddenBooster
 import us.timinc.mc.cobblemon.unchained.modules.IvBooster
 import us.timinc.mc.cobblemon.unchained.modules.ShinyBooster
+import us.timinc.mc.cobblemon.unchained.modules.SpawnChainer
 
 object UnchainedMod : ModInitializer {
     @Suppress("unused", "MemberVisibilityCanBePrivate")
@@ -13,5 +14,6 @@ object UnchainedMod : ModInitializer {
         ShinyBooster.initialize()
         HiddenBooster.initialize()
         IvBooster.initialize()
+        SpawnChainer.initialize()
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractActionInfluenceBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractActionInfluenceBooster.kt
@@ -7,7 +7,7 @@ import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 
-abstract class AbstractInfluenceBooster(
+abstract class AbstractActionInfluenceBooster(
     open val player: ServerPlayer,
     open val config: AbstractBoostConfig,
     open val debug: (String) -> Unit,
@@ -26,8 +26,14 @@ abstract class AbstractInfluenceBooster(
 
         val points = config.getPointsFromThreshold(player, species, form)
 
-        boost(action, pokemon, species, form, points)
+        boostAction(action, pokemon, species, form, points)
     }
 
-    abstract fun boost(action: PokemonSpawnAction, pokemon: Pokemon, species: ResourceLocation, form: String, points: Int)
+    abstract fun boostAction(
+        action: PokemonSpawnAction,
+        pokemon: Pokemon,
+        species: ResourceLocation,
+        form: String,
+        points: Double,
+    )
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBoostConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBoostConfig.kt
@@ -8,7 +8,7 @@ import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.counter.api.CounterType
 import us.timinc.mc.cobblemon.counter.extensions.getCounterManager
 
-abstract class AbstractBoostConfig {
+abstract class AbstractBoostConfig(val defaultValue: Double = 0.0) {
     val debug: Boolean = false
     val blacklist = mutableSetOf<String>()
     val whitelist = mutableSetOf<String>()
@@ -17,9 +17,9 @@ abstract class AbstractBoostConfig {
     abstract val koCountPoints: Int
     abstract val captureStreakPoints: Int
     abstract val captureCountPoints: Int
-    abstract val thresholds: Map<Int, Int>
+    abstract val thresholds: Map<Int, Double>
 
-    fun getPointsFromThreshold(player: ServerPlayer, species: ResourceLocation, form: String): Int {
+    fun getPointsFromThreshold(player: ServerPlayer, species: ResourceLocation, form: String): Double {
         val calcForm = if (careAboutForms) form else null
         val counterManager = player.getCounterManager()
 
@@ -31,11 +31,11 @@ abstract class AbstractBoostConfig {
 
         val points = (koStreak * koStreakPoints) + (koCount * koCountPoints) + (captureStreak * captureStreakPoints) + (captureCount * captureCountPoints)
 
-        return thresholds.maxOfOrNull { if (it.key <= points) it.value else 0 } ?: 0
+        return thresholds.maxOfOrNull { if (it.key <= points) it.value else defaultValue } ?: defaultValue
     }
 
-    fun getPointsFromThreshold(player: ServerPlayer, pokemon: Pokemon): Int {
-        if (!Util.matchesList(pokemon, whitelist, blacklist)) return 0
+    fun getPointsFromThreshold(player: ServerPlayer, pokemon: Pokemon): Double {
+        if (!Util.matchesList(pokemon, whitelist, blacklist)) return 0.0
         return getPointsFromThreshold(player, pokemon.species.resourceIdentifier, pokemon.form.name)
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBoostConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBoostConfig.kt
@@ -29,7 +29,8 @@ abstract class AbstractBoostConfig(val defaultValue: Double = 0.0) {
         val captureStreak = counterManager.getStreakCount(CounterType.CAPTURE, species, calcForm)
         val captureCount = counterManager.getCount(CounterType.CAPTURE, species, calcForm)
 
-        val points = (koStreak * koStreakPoints) + (koCount * koCountPoints) + (captureStreak * captureStreakPoints) + (captureCount * captureCountPoints)
+        val points =
+            (koStreak * koStreakPoints) + (koCount * koCountPoints) + (captureStreak * captureStreakPoints) + (captureCount * captureCountPoints)
 
         return thresholds.maxOfOrNull { if (it.key <= points) it.value else defaultValue } ?: defaultValue
     }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractBooster.kt
@@ -8,7 +8,7 @@ import us.timinc.mc.cobblemon.unchained.config.ConfigBuilder
 
 abstract class AbstractBooster<T : AbstractBoostConfig>(
     val name: String,
-    val configClass: Class<T>
+    val configClass: Class<T>,
 ) {
     val logger: Logger = LogManager.getLogger("$MOD_ID/$name")
     lateinit var config: T

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractWeightInfluenceBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/api/AbstractWeightInfluenceBooster.kt
@@ -1,0 +1,17 @@
+package us.timinc.mc.cobblemon.unchained.api
+
+import com.cobblemon.mod.common.api.spawning.context.SpawningContext
+import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
+import com.cobblemon.mod.common.api.spawning.detail.SpawnDetail
+import com.cobblemon.mod.common.api.spawning.influence.SpawningInfluence
+import net.minecraft.server.level.ServerPlayer
+
+abstract class AbstractWeightInfluenceBooster : SpawningInfluence {
+    override fun affectWeight(detail: SpawnDetail, ctx: SpawningContext, weight: Float): Float {
+        val player = ctx.cause.entity as? ServerPlayer
+        if (detail !is PokemonSpawnDetail || player === null) return super.affectWeight(detail, ctx, weight)
+        return super.affectWeight(detail, ctx, boostWeight(detail, player, weight))
+    }
+
+    abstract fun boostWeight(detail: PokemonSpawnDetail, player: ServerPlayer, weight: Float): Float
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
@@ -1,7 +1,6 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
 import com.cobblemon.mod.common.api.Priority
-import com.cobblemon.mod.common.api.pokemon.PokemonSpecies
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnAction
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
 import com.cobblemon.mod.common.pokemon.Pokemon
@@ -9,7 +8,7 @@ import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
 import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
-import us.timinc.mc.cobblemon.unchained.api.AbstractInfluenceBooster
+import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import kotlin.random.Random.Default.nextInt
 
 object HiddenBooster : AbstractBooster<HiddenBoosterConfig>(
@@ -26,13 +25,13 @@ class HiddenBoosterInfluence(
     override val config: HiddenBoosterConfig,
     override val debug: (String) -> Unit
 ) :
-    AbstractInfluenceBooster(player, config, debug) {
-    override fun boost(
+    AbstractActionInfluenceBooster(player, config, debug) {
+    override fun boostAction(
         action: PokemonSpawnAction,
         pokemon: Pokemon,
         species: ResourceLocation,
         form: String,
-        points: Int
+        points: Double
     ) {
         val totalMarbles = config.marbles
         val ability = pokemon.form.abilities.mapping[Priority.LOW]?.random()?.template?.name
@@ -42,7 +41,7 @@ class HiddenBoosterInfluence(
             return
         }
 
-        if (points == 0) {
+        if (points == 0.0) {
             debug("conclusion: player hasn't unlocked hidden ability chance")
             return
         }
@@ -64,11 +63,11 @@ class HiddenBoosterInfluence(
     }
 }
 
-class HiddenBoosterConfig : AbstractBoostConfig() {
+class HiddenBoosterConfig : AbstractBoostConfig(1.0) {
     override val koStreakPoints = 100
     override val koCountPoints = 1
     override val captureStreakPoints = 0
     override val captureCountPoints = 0
-    override val thresholds: Map<Int, Int> = mutableMapOf(99 to 1)
+    override val thresholds: Map<Int, Double> = mutableMapOf(99 to 1.0)
     val marbles = 5
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
@@ -6,9 +6,9 @@ import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
+import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
 import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
-import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import kotlin.random.Random.Default.nextInt
 
 object HiddenBooster : AbstractBooster<HiddenBoosterConfig>(
@@ -23,7 +23,7 @@ object HiddenBooster : AbstractBooster<HiddenBoosterConfig>(
 class HiddenBoosterInfluence(
     override val player: ServerPlayer,
     override val config: HiddenBoosterConfig,
-    override val debug: (String) -> Unit
+    override val debug: (String) -> Unit,
 ) :
     AbstractActionInfluenceBooster(player, config, debug) {
     override fun boostAction(
@@ -31,7 +31,7 @@ class HiddenBoosterInfluence(
         pokemon: Pokemon,
         species: ResourceLocation,
         form: String,
-        points: Double
+        points: Double,
     ) {
         val totalMarbles = config.marbles
         val ability = pokemon.form.abilities.mapping[Priority.LOW]?.random()?.template?.name

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
@@ -8,9 +8,9 @@ import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
+import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
 import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
-import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import kotlin.math.min
 
 object IvBooster : AbstractBooster<IvBoosterConfig>(

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
@@ -10,7 +10,7 @@ import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
 import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
-import us.timinc.mc.cobblemon.unchained.api.AbstractInfluenceBooster
+import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
 import kotlin.math.min
 
 object IvBooster : AbstractBooster<IvBoosterConfig>(
@@ -26,14 +26,15 @@ class IvBoosterInfluence(
     override val player: ServerPlayer,
     override val config: IvBoosterConfig,
     override val debug: (String) -> Unit,
-) : AbstractInfluenceBooster(player, config, debug) {
-    override fun boost(
+) : AbstractActionInfluenceBooster(player, config, debug) {
+    override fun boostAction(
         action: PokemonSpawnAction,
         pokemon: Pokemon,
         species: ResourceLocation,
         form: String,
-        points: Int,
+        points: Double,
     ) {
+        val points = points.toInt()
         debug("${player.name.string} wins with $points points, $points perfect IVs")
         if (points <= 0) {
             debug("conclusion: player didn't get any perfect IVs")
@@ -66,10 +67,10 @@ class IvBoosterInfluence(
     }
 }
 
-class IvBoosterConfig : AbstractBoostConfig() {
+class IvBoosterConfig : AbstractBoostConfig(1.0) {
     override val koStreakPoints = 0
     override val koCountPoints = 0
     override val captureStreakPoints = 1
     override val captureCountPoints = 0
-    override val thresholds: Map<Int, Int> = mutableMapOf(Pair(5, 1), Pair(10, 2), Pair(20, 3), Pair(30, 4))
+    override val thresholds: Map<Int, Double> = mutableMapOf(Pair(5, 1.0), Pair(10, 2.0), Pair(20, 3.0), Pair(30, 4.0))
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
@@ -1,8 +1,8 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
 import com.cobblemon.mod.common.api.events.CobblemonEvents
-import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
+import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
 
 object ShinyBooster : AbstractBooster<ShinyBoostConfig>(
     "shinyBooster",

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
@@ -15,16 +15,16 @@ object ShinyBooster : AbstractBooster<ShinyBoostConfig>(
                 val boost = config.getPointsFromThreshold(player, pokemon)
                 val newRate = currentRate / (boost + 1)
                 debug("A ${pokemon.species.name}|${pokemon.form.name} has spawned on ${player.name.string} and received a boost of $boost to change the rate to $newRate.")
-                newRate
+                newRate.toFloat()
             }
         }
     }
 }
 
-class ShinyBoostConfig : AbstractBoostConfig() {
+class ShinyBoostConfig : AbstractBoostConfig(1.0) {
     override val koStreakPoints = 1
     override val koCountPoints = 0
     override val captureStreakPoints = 0
     override val captureCountPoints = 0
-    override val thresholds: Map<Int, Int> = mutableMapOf(Pair(100, 1), Pair(300, 2), Pair(500, 3))
+    override val thresholds: Map<Int, Double> = mutableMapOf(Pair(100, 1.0), Pair(300, 2.0), Pair(500, 3.0))
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
@@ -1,0 +1,51 @@
+package us.timinc.mc.cobblemon.unchained.modules
+
+import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
+import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
+import net.minecraft.server.level.ServerPlayer
+import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
+import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
+import us.timinc.mc.cobblemon.unchained.api.AbstractWeightInfluenceBooster
+
+object SpawnChainer : AbstractBooster<SpawnChainerConfig>(
+    "spawnChainer",
+    SpawnChainerConfig::class.java
+) {
+    override fun subInit() {
+        PlayerSpawnerFactory.influenceBuilders.add { SpawnChainerInfluence(config, ::debug) }
+    }
+}
+
+class SpawnChainerInfluence(
+    val config: SpawnChainerConfig,
+    val debug: (String) -> Unit,
+) : AbstractWeightInfluenceBooster() {
+    override fun boostWeight(detail: PokemonSpawnDetail, player: ServerPlayer, weight: Float): Float {
+        val species = detail.pokemon.species?.asIdentifierDefaultingNamespace() ?: return weight
+        val form = detail.pokemon.form ?: "Normal"
+
+        val multiplier = config.getPointsFromThreshold(player, species, form)
+
+        if (multiplier != 1.0) {
+            debug("${detail.pokemon.originalString} spawn boosted by $multiplier for ${player.name.string}")
+        }
+        return (weight * multiplier).toFloat()
+    }
+}
+
+class SpawnChainerConfig : AbstractBoostConfig(1.0) {
+    override val koStreakPoints: Int = 1
+    override val koCountPoints: Int = 0
+    override val captureStreakPoints: Int = 0
+    override val captureCountPoints: Int = 0
+    override val thresholds: Map<Int, Double> = mutableMapOf(
+        5 to 1.2,
+        10 to 1.5,
+        20 to 2.0,
+        30 to 2.5,
+        50 to 3.0,
+        75 to 3.5,
+        100 to 4.0,
+    )
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon_unchained",
-  "version": "1.6-fabric-1.0.1",
+  "version": "1.6-fabric-1.1.0",
   "name": "Cobblemon Unchained",
   "description": "Chain KOs and captures to boost spawns around you.",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,9 @@
   "version": "1.6-fabric-1.0.1",
   "name": "Cobblemon Unchained",
   "description": "Chain KOs and captures to boost spawns around you.",
-  "authors": ["TimInc aka Timothy Metcalfe"],
+  "authors": [
+    "TimInc aka Timothy Metcalfe"
+  ],
   "license": "MIT",
   "environment": "*",
   "entrypoints": {


### PR DESCRIPTION
* unlock thresholds to multiply nearby spawns based on your current points for them. by default, ko streak of 5 gives x1.2, 10 gives 1.5x, 20 gives 2.0x, 30 gives 2.5x, 50 gives 3.0x, 75 gives 3.5x, and 100+ gives 4.0x
* swapped points from threshold from Int to Double
* AbstractInfluenceBooster -> AbstractActionInfluenceBooster
* added AbstractWeightInfluenceBooster
* AbstractBoostConfigs can now receive default value for when threshold not unlocked