### PR TITLE
v1.2.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.2.1
+mod_version=1.6-fabric-1.2.3
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=unchained
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/HiddenBooster.kt
@@ -4,8 +4,8 @@ import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnAction
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.pokemon.Pokemon
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
@@ -19,7 +19,7 @@ object HiddenBooster : AbstractBooster<HiddenBoosterConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { HiddenBoosterInfluence(config, ::debug, it) }
-        ServerLifecycleEvents.SERVER_STARTED.register { _ ->
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
             fishingSpawner.influences.add(HiddenBoosterInfluence(config, ::debug))
         }
     }
@@ -69,7 +69,7 @@ class HiddenBoosterInfluence(
     }
 }
 
-class HiddenBoosterConfig : AbstractBoostConfig(1.0) {
+class HiddenBoosterConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 100
     override val koCountPoints = 1
     override val captureStreakPoints = 0

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/IvBooster.kt
@@ -1,13 +1,14 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
+import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.pokemon.stats.Stat
 import com.cobblemon.mod.common.api.pokemon.stats.Stats
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnAction
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.pokemon.IVs
 import com.cobblemon.mod.common.pokemon.Pokemon
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractActionInfluenceBooster
@@ -21,7 +22,7 @@ object IvBooster : AbstractBooster<IvBoosterConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { IvBoosterInfluence(config, ::debug, it) }
-        ServerLifecycleEvents.SERVER_STARTED.register { _ ->
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
             fishingSpawner.influences.add(IvBoosterInfluence(config, ::debug))
         }
     }
@@ -73,7 +74,7 @@ class IvBoosterInfluence(
     }
 }
 
-class IvBoosterConfig : AbstractBoostConfig(1.0) {
+class IvBoosterConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 0
     override val koCountPoints = 0
     override val captureStreakPoints = 1

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/ShinyBooster.kt
@@ -21,7 +21,7 @@ object ShinyBooster : AbstractBooster<ShinyBoostConfig>(
     }
 }
 
-class ShinyBoostConfig : AbstractBoostConfig(1.0) {
+class ShinyBoostConfig : AbstractBoostConfig(0.0) {
     override val koStreakPoints = 1
     override val koCountPoints = 0
     override val captureStreakPoints = 0

--- a/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/unchained/modules/SpawnChainer.kt
@@ -1,10 +1,11 @@
 package us.timinc.mc.cobblemon.unchained.modules
 
+import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.spawning.BestSpawner.fishingSpawner
 import com.cobblemon.mod.common.api.spawning.detail.PokemonSpawnDetail
 import com.cobblemon.mod.common.api.spawning.spawner.PlayerSpawnerFactory
+import com.cobblemon.mod.common.platform.events.PlatformEvents
 import com.cobblemon.mod.common.util.asIdentifierDefaultingNamespace
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
 import net.minecraft.server.level.ServerPlayer
 import us.timinc.mc.cobblemon.unchained.api.AbstractBoostConfig
 import us.timinc.mc.cobblemon.unchained.api.AbstractBooster
@@ -16,7 +17,7 @@ object SpawnChainer : AbstractBooster<SpawnChainerConfig>(
 ) {
     override fun subInit() {
         PlayerSpawnerFactory.influenceBuilders.add { SpawnChainerInfluence(config, ::debug) }
-        ServerLifecycleEvents.SERVER_STARTED.register { _ ->
+        PlatformEvents.SERVER_STARTED.subscribe(Priority.LOWEST) { _ ->
             fishingSpawner.influences.add(SpawnChainerInfluence(config, ::debug))
         }
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon_unchained",
-  "version": "1.6-fabric-1.2.1",
+  "version": "1.6-fabric-1.2.3",
   "name": "Cobblemon Unchained",
   "description": "Chain KOs and captures to boost spawns around you.",
   "authors": [


### PR DESCRIPTION
* Only Spawn Chainer should have ever had 1.0 as the default defaultValue, as its is multiplicative.
* Had to lower the priority on attaching to the fishing spawner because it attaches *during* server load.